### PR TITLE
Explicitly declare dependency on 'Stringable'

### DIFF
--- a/src/StringableStream.php
+++ b/src/StringableStream.php
@@ -5,7 +5,7 @@ namespace StreamInterop\Interface;
 
 use Stringable;
 
-interface StringableStream extends Stream
+interface StringableStream extends Stream, Stringable
 {
     public function __toString() : string;
 }


### PR DESCRIPTION
According to PHP manual, objects implementing `__toString()` should explicitly declare it's dependency on `Stringable`. I think you were already on to that @pmjones as you had already imported (`use Stringable;`) the interface.