### PR TITLE
Consider a separate SizableInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,6 @@ The _Stream_ interface defines these properties common to all streams:
 
 It also defines these methods common to all streams:
 
-- `public function getSize() : ?int`
-    - Returns the length of the stream in bytes as if by the [`fstat()`][] value for `size`, or null on error or if indeterminate.
-
 - `public function isClosed() : bool`
     - Returns true if the stream has been closed, or false if not.
 
@@ -84,6 +81,17 @@ The _ClosableStream_ interface extends _Stream_ to define this method:
 Notes:
 
 - **Not all _Stream_ implementations need to be closable.** It may be important for resource closing to be handled by a separate service or authority, and not be closable by _Stream_ consumers.
+
+### _SizableStream_
+
+The _SizableStream_ interface extends _Stream_ to define this method:
+
+- `public function getSize() : int<0,max>`
+    - Returns the length of the stream in bytes as if by the [`fstat()`][] value for `size`, or null on error or if indeterminate.
+
+Notes:
+
+- **Not all _Stream_ implementations need to be sizable.** Some underlying resources may be unable to report a size; for example, remote or write-only streams.
 
 ### _ReadableStream_
 

--- a/src/SizableStream.php
+++ b/src/SizableStream.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace StreamInterop\Interface;
+
+interface SizableStream extends Stream
+{
+    /**
+     * @return int<0, max>
+     */
+    public function getSize() : int;
+}

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -34,8 +34,6 @@ interface Stream
      */
     public mixed $resource { get; }
 
-    public function getSize() : ?int;
-
     public function isClosed() : bool;
 
     public function isOpen() : bool;


### PR DESCRIPTION
( in response to https://github.com/stream-interop/interface/issues/9#issuecomment-2600970346 )

On further consideration, I'm not entirely sold on splitting this off, even though it is quite uncommon. Leaving it in _Stream_ seems reasonable enough, even when the size might be unavailable/indeterminable, since Stream::getSize() allows null in those cases.

@nbish11 @koriym Your thoughts?
